### PR TITLE
fix: 自分と紐付かないからだに対してメモを追加できるバグを修正 #51

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,6 +1,6 @@
 class NotesController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_body, only: :new
+  before_action :set_body, only: %i[create update]
   before_action :set_note, only: %i[show edit update destroy]
 
   def index
@@ -10,14 +10,19 @@ class NotesController < ApplicationController
   end
 
   def new
-    @note = Note.new(body: @body)
+    # 追加先のからだがクエリパラメータに指定されるケースと、未指定のケースの2通りがあるため
+    # find_byで「からだ」を取得する。nilは未指定として扱う。
+    body_or_nil = current_user.family.bodies.find_by(id: params[:body_id])
+    @note = Note.new(body: body_or_nil)
   end
 
   def edit
   end
 
   def create
-    @note = Note.new(note_params)
+    # current_userと無関係なからだにメモが追加されないようにbody_idを直接渡すのではなく
+    # オブジェクトとして取得しておいてそれを渡す。(updateも同様)
+    @note = Note.new(note_params.merge!(body: @body))
     if @note.save
       redirect_to @note, success: 'メモを作成しました'
     else
@@ -26,7 +31,7 @@ class NotesController < ApplicationController
   end
 
   def update
-    if @note.update(note_params)
+    if @note.update(note_params.merge!(body: @body))
       redirect_to @note, success: 'メモを更新しました'
     else
       render :edit
@@ -41,7 +46,7 @@ class NotesController < ApplicationController
   private
 
   def set_body
-    @body = current_user.family.bodies.find_by(id: params[:body_id])
+    @body = current_user.family.bodies.find(params[:note][:body_id])
   end
 
   def set_note
@@ -49,6 +54,6 @@ class NotesController < ApplicationController
   end
 
   def note_params
-    params.require(:note).permit(:detail, :noted_at, :body_id)
+    params.require(:note).permit(:detail, :noted_at)
   end
 end

--- a/spec/controllers/notes_controller_spec.rb
+++ b/spec/controllers/notes_controller_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe NotesController, type: :controller do
+  describe 'create' do
+    it '自分と無関係なからだに対してメモを追加しようした場合、例外をスローすること #51' do
+      user = FactoryBot.create(:user)
+      other_user = FactoryBot.create(:user)
+      body_of_other_user = FactoryBot.create(:body, family: other_user.family)
+      note_params = FactoryBot.attributes_for(:note)
+      sign_in user
+      expect do
+        post :create, params: {
+          # ログインユーザーとは紐づかない「からだ」を指定する
+          note: note_params.merge!(body_id: body_of_other_user.id)
+        }
+      end.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -58,4 +58,7 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  # コントローラスペックで Devise のテストヘルパーを使用する
+  config.include Devise::Test::ControllerHelpers, type: :controller
 end


### PR DESCRIPTION
#51 のバグを修正しました。
修正方法を再考しましたが、 #50 と近い形に落ち着きました。

以下は再考結果です。
* クエリパラメータからのbody_idの取得は newアクション固有の話なので、set_bodyに書かず、newアクションへ移動
  * nilに明示的に意味をもたせていることがわかるように、変数名に`or_nil`を追加
* set_bodyメソッドで、create, updateのリクエストからbodyを取得する際、permitを経由せず直接paramsからbody_idを取得した。permitを経由する利点が思いつかなかったので削っています
* create, updateでは[merge!](https://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-merge-21)メソッドでマージするようにし、1行で書いています

その他、コメントでの補足も加えました。
